### PR TITLE
Bump actions/cache from 4 to 5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
## Summary
Updates actions/cache from v4 to v5 in the GitHub Actions CI workflow.

This PR supersedes #37 which was based on old code and had dependency conflicts.

## Changes
- Updated `.github/workflows/CI.yml` to use `actions/cache@v5` instead of `actions/cache@v4`

## Notes
- This is a workflow-only change and does not affect Julia code
- actions/cache@v5 runs on Node.js 24 runtime and requires Actions Runner version 2.327.1 or higher, which is satisfied by GitHub-hosted runners
- The new cache service has improved performance and reliability
- The change is fully backward compatible

Closes #37

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)