### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-style = "sciml"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/src/BridgeDiffEq.jl
+++ b/src/BridgeDiffEq.jl
@@ -9,22 +9,24 @@ import Bridge
 
 import DiffEqBase: solve
 
-const warnkeywords = (:save_idxs, :d_discontinuities, :unstable_check, :save_everystep,
+const warnkeywords = (
+    :save_idxs, :d_discontinuities, :unstable_check, :save_everystep,
     :save_end, :initialize_save, :adaptive, :abstol, :reltol, :dtmax,
     :dtmin, :force_dtmin, :internalnorm, :gamma, :beta1, :beta2,
     :qmax, :qmin, :qsteady_min, :qsteady_max, :qoldinit, :failfactor,
     :maxiters, :isoutofdomain, :unstable_check,
-    :calck, :progress, :tstops, :saveat, :dense)
+    :calck, :progress, :tstops, :saveat, :dense,
+)
 
 function __init__()
-    global warnlist = Set(warnkeywords)
+    return global warnlist = Set(warnkeywords)
 end
 
 include("algorithms.jl")
 include("solve.jl")
 
 export BridgeAlgorithm, BridgeEuler, BridgeHeun, BridgeSRK, BridgeR3, BridgeBS3,
-       BridgeMdb
+    BridgeMdb
 
 include("precompilation.jl")
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,13 +1,16 @@
 function solve(
-        prob::Union{DiffEqBase.AbstractODEProblem{uType, tType, isinplace},
-            DiffEqBase.AbstractSDEProblem{uType, tType, isinplace}},
+        prob::Union{
+            DiffEqBase.AbstractODEProblem{uType, tType, isinplace},
+            DiffEqBase.AbstractSDEProblem{uType, tType, isinplace},
+        },
         alg::AlgType,
         timeseries = nothing, ts = nothing, ks = nothing;
         verbose = true,
         dt = nothing,
         timeseries_errors = true,
         callback = nothing,
-        kwargs...) where {uType, tType, isinplace, AlgType <: BridgeAlgorithm}
+        kwargs...
+    ) where {uType, tType, isinplace, AlgType <: BridgeAlgorithm}
     if isnothing(dt)
         error("dt required for fixed timestep methods.")
     end
@@ -63,8 +66,10 @@ function solve(
         end
     end
 
-    DiffEqBase.build_solution(prob, alg, u.tt, u.yy,
+    return DiffEqBase.build_solution(
+        prob, alg, u.tt, u.yy,
         W = W,
         timeseries_errors = timeseries_errors,
-        retcode = DiffEqBase.ReturnCode.Success)
+        retcode = DiffEqBase.ReturnCode.Success
+    )
 end


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)