### PR TITLE
Add JET static analysis tests and fix explicit imports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 Bridge = "0.11"
 DiffEqBase = "6"
+JET = "0.9"
 PrecompileTools = "1"
 Reexport = "1"
 StaticArrays = "1"
@@ -20,7 +21,8 @@ julia = "1.10"
 
 [extras]
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "Test"]
+test = ["ExplicitImports", "JET", "Test"]

--- a/src/BridgeDiffEq.jl
+++ b/src/BridgeDiffEq.jl
@@ -1,9 +1,10 @@
 module BridgeDiffEq
 
-using Reexport
+using Reexport: Reexport, @reexport
 @reexport using DiffEqBase
 
-using StaticArrays
+using DiffEqBase: DiffEqBase, check_keywords, isinplace, warn_compat
+using StaticArrays: StaticArrays
 using LinearAlgebra: Diagonal
 import Bridge
 

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,4 +1,4 @@
-using PrecompileTools
+using PrecompileTools: PrecompileTools, @compile_workload, @setup_workload
 using DiffEqBase: ODEProblem, SDEProblem
 
 @setup_workload begin

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -1,0 +1,80 @@
+using BridgeDiffEq
+using JET
+using StaticArrays
+using Test
+
+@testset "JET static analysis" begin
+    # Setup test problems
+    f(u, p, t) = u
+    g(u, p, t) = u
+    u0 = 0.5
+    dt = 1 // 16
+    tspan = (0.0, 1.0)
+
+    prob_ode = ODEProblem(f, u0, tspan)
+    prob_sde = SDEProblem(f, g, u0, tspan)
+
+    @testset "Scalar ODE type stability" begin
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_ode, BridgeR3(),
+            dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_ode, BridgeBS3(),
+            dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+    end
+
+    @testset "Scalar SDE type stability" begin
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_sde, BridgeEuler(),
+            dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_sde, BridgeHeun(),
+            dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_sde, BridgeSRK(),
+            dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+    end
+
+    @testset "Vector type stability" begin
+        u0_vec = @SVector [2.0, 3.0]
+        prob_ode_vec = ODEProblem(f, u0_vec, tspan)
+        prob_sde_vec = SDEProblem(f, g, u0_vec, tspan)
+
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_ode_vec, BridgeR3(),
+            dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_ode_vec, BridgeBS3(),
+            dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_sde_vec,
+            BridgeEuler(), dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+
+        rep = @report_opt target_modules = (BridgeDiffEq,) solve(
+            prob_sde_vec,
+            BridgeHeun(), dt = dt
+        )
+        @test length(JET.get_reports(rep)) == 0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,4 +63,10 @@ const GROUP = get(ENV, "GROUP", "all")
             include("explicit_imports.jl")
         end
     end
+
+    if GROUP == "all" || GROUP == "jet"
+        @testset "JET Static Analysis" begin
+            include("jet_tests.jl")
+        end
+    end
 end


### PR DESCRIPTION
## Summary

- Add JET.jl as a test dependency for static analysis testing
- Add `test/jet_tests.jl` with comprehensive JET `@report_opt` tests for all solver algorithms
- Fix explicit imports to pass ExplicitImports checks (the existing tests were failing due to implicit imports)

## Changes

### JET Analysis Results
The package was already fully type-stable! JET.report_package found no issues, and all `@report_opt` tests pass with 0 reports.

### Explicit Imports Fixed
- `BridgeDiffEq.jl`: Import `Reexport`, `DiffEqBase` symbols, and `StaticArrays` explicitly
- `precompilation.jl`: Import PrecompileTools macros explicitly

### New Tests Added
JET tests for:
- Scalar ODE solving (BridgeR3, BridgeBS3)
- Scalar SDE solving (BridgeEuler, BridgeHeun, BridgeSRK)
- Vector ODE/SDE solving with StaticArrays

## Test plan

- [x] Ran `Pkg.test()` locally - all 31 tests pass
- [x] JET static analysis passes with 0 reports
- [x] ExplicitImports tests now pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)