### PR TITLE
Improve precompilation: Add SVector workload for faster TTFX

### DIFF
--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -9,6 +9,7 @@ using DiffEqBase: ODEProblem, SDEProblem
     tspan = (0.0, 1.0)
 
     @compile_workload begin
+        # Scalar problems
         prob_ode = ODEProblem(f, u0, tspan)
         solve(prob_ode, BridgeR3(), dt = dt)
         solve(prob_ode, BridgeBS3(), dt = dt)
@@ -17,5 +18,15 @@ using DiffEqBase: ODEProblem, SDEProblem
         solve(prob_sde, BridgeEuler(), dt = dt)
         solve(prob_sde, BridgeHeun(), dt = dt)
         solve(prob_sde, BridgeSRK(), dt = dt)
+
+        # SVector problems (common vector use case)
+        u0_vec = StaticArrays.@SVector [1.0, 1.0]
+        prob_ode_vec = ODEProblem(f, u0_vec, tspan)
+        solve(prob_ode_vec, BridgeR3(), dt = dt)
+        solve(prob_ode_vec, BridgeBS3(), dt = dt)
+
+        prob_sde_vec = SDEProblem(f, g, u0_vec, tspan)
+        solve(prob_sde_vec, BridgeEuler(), dt = dt)
+        solve(prob_sde_vec, BridgeHeun(), dt = dt)
     end
 end


### PR DESCRIPTION
## Summary

- Added SVector{2, Float64} precompilation workload to improve TTFX for vector problems
- Precompiles ODE (BridgeR3, BridgeBS3) and SDE (BridgeEuler, BridgeHeun) solvers with SVector inputs

## Benchmark Results

### Baseline TTFX (Fresh Julia session)
- Package load time: ~2.0-2.6s
- Scalar ODE solve: ~40-60ms
- Scalar SDE solve: ~60-90ms
- SVector ODE solve: 84-305ms  
- SVector SDE solve: 70-276ms

### After Changes - SVector{2} TTFX
| Algorithm | Before | After | Improvement |
|-----------|--------|-------|-------------|
| BridgeR3 | 84ms | 39ms | 54% faster |
| BridgeBS3 | 305ms | 96ms | 69% faster |
| BridgeEuler | 276ms | 63ms | 77% faster |
| BridgeHeun | 70ms | 63ms | 10% faster |

### Precompilation Time
- Before: ~3.7s
- After: ~4.4s  
- Increase: ~0.7s (acceptable tradeoff)

## Analysis

- Ran SnoopCompile invalidation analysis: 48 low-impact invalidation trees, all from dependencies (StaticArrays, FillArrays, etc.) - no high-impact invalidations from BridgeDiffEq
- Scalar problems were already well-precompiled
- Vector problems (especially SVector) had significant compilation overhead at runtime

## Test plan

- [x] Core functionality tests pass
- [x] Allocation tests pass
- [x] Verified TTFX improvements in fresh Julia sessions

Note: The ExplicitImports test fails due to pre-existing implicit imports in the codebase - this is unrelated to these changes.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)